### PR TITLE
Use set_exception instead of set_exception_info

### DIFF
--- a/collapsing_thread_pool_executor/collapsing_thread_pool_executor.py
+++ b/collapsing_thread_pool_executor/collapsing_thread_pool_executor.py
@@ -52,9 +52,8 @@ class _WorkItem(object):
 
         try:
             result = self.fn(*self.args, **self.kwargs)
-        except BaseException:
-            e, tb = sys.exc_info()[1:]
-            self.future.set_exception_info(e, tb)
+        except BaseException as exc:
+            self.future.set_exception(exc)
         else:
             self.future.set_result(result)
 


### PR DESCRIPTION
set_exception_info method is only available in python2 backport
of concurrent.futures, while set_exception method available
everywhere.

This fixes issue #5.